### PR TITLE
Add a Dockerfile :)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.4.2
+
+RUN mkdir -p /go/src/github.com/calavera/gh-rel /data
+WORKDIR /go/src/github.com/calavera/gh-rel
+
+COPY . /go/src/github.com/calavera/gh-rel
+
+RUN go-wrapper download && \
+    go-wrapper install
+
+VOLUME ["/data"]
+
+ENTRYPOINT ["/go/bin/gh-rel", "--db=/data/db"]
+CMD ["serve"]

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func fullMain() {
 
 	rootCmd := &cobra.Command{Use: "gh-rel"}
 	rootCmd.AddCommand(cmdAdd, cmdServe)
-	rootCmd.Flags().StringVarP(&dbPath, "db", "d", db.DefaultPath, "path to the database file")
+	rootCmd.PersistentFlags().StringVarP(&dbPath, "db", "d", db.DefaultPath, "path to the database file")
 
 	rootCmd.Execute()
 }


### PR DESCRIPTION
I couldn't resists but to add a `Dockerfile` :sweat_smile:.

``` bash
λ docker build -t calavera/gh-rel .
# […]
λ docker run --rm -ti -v /tmp/data:/data calavera/gh-rel add docker/distribution
λ docker run --rm -ti -v /tmp/data:/data calavera/gh-rel add docker/compose
λ docker run --rm -ti -v /tmp/data:/data -p 8888:888 calavera/gh-rel                                                                                          
[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] GET   /assets/*filepath         --> github.com/gin-gonic/gin.func·011 (3 handlers)
[GIN-debug] HEAD  /assets/*filepath         --> github.com/gin-gonic/gin.func·011 (3 handlers)
[GIN-debug] GET   /                         --> main.func·003 (3 handlers)
[GIN-debug] Listening and serving HTTP on :8888
No media type for this response
[GIN] 2015/08/08 - 20:57:22 | 200 |  2.330971997s | 172.17.42.1:37386 |   GET     /
No media type for this response
No media type for this response
[GIN] 2015/08/08 - 20:57:28 | 200 |  1.866008868s | 172.17.42.1:37386 |   GET     /
[GIN] 2015/08/08 - 20:57:28 | 304 |      99.349µs | 172.17.42.1:37386 |   GET     /assets/css/primer.css
[GIN] 2015/08/08 - 20:57:28 | 304 |     137.161µs | 172.17.42.1:37390 |   GET     /assets/css/octicons.css
[GIN] 2015/08/08 - 20:57:28 | 304 |      63.238µs | 172.17.42.1:37386 |   GET     /assets/css/main.css
[GIN] 2015/08/08 - 20:57:28 | 304 |      57.207µs | 172.17.42.1:37386 |   GET     /assets/images/mini-logo.svg
```

The change on `main.go` is there because each time I ran `gh-rel --db=… serve` it was complaining :sweat:.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
