### PR TITLE
Changing title from 'Docker Platform' to 'Docker Core'

### DIFF
--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -15,7 +15,7 @@
             <object type="image/svg+xml" data="/assets/images/mini-logo.svg"></object>
           </div>
           <div class="four-fifth column">
-            <h1>Docker platform releases</h1>
+            <h1>Docker Core Releases</h1>
           </div>
         </div>
       </div>
@@ -28,10 +28,10 @@
             Projects
           </div>
           <div class="one-fourth column release">
-            Latest release
+            Latest Release
           </div>
           <div class="one-fourth column release">
-            Next candidate
+            Next Candidate
           </div>
         </div>
 


### PR DESCRIPTION
Signed-off-by: Amy Lindburg amy.lindburg@docker.com

I believe that we are referring to the collection of our tools as "Docker Core" at present.
