### PR TITLE
Serialize release data.

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -22,8 +22,9 @@ func (p Project) Repo() string {
 }
 
 type Release struct {
-	Tag     string
-	HTMLURL string
+	Tag        string
+	HTMLURL    string
+	Prerelease bool
 }
 
 func wipRelease() Release {


### PR DESCRIPTION
Put data as JSON in the database, so we can store more information.

Signed-off-by: David Calavera david.calavera@gmail.com
